### PR TITLE
Allow renderer to accept more kinds of data, change language back to Should from To given the use of Ω

### DIFF
--- a/ansi/ansi_test.go
+++ b/ansi/ansi_test.go
@@ -21,15 +21,15 @@ var _ = Describe("Color", func() {
 		)
 
 		It("performs the same action as ANSI codes", func() {
-			Ω(ColorizeWithCode(code, str)).To(Equal(result))
+			Ω(ColorizeWithCode(code, str)).Should(Equal(result))
 		})
 
 		It("returns the string if an invalid code is given", func() {
-			Ω(ColorizeWithCode("invalid", "testing")).To(Equal("testing"))
+			Ω(ColorizeWithCode("invalid", "testing")).Should(Equal("testing"))
 		})
 
 		It("colorizes xterm codes as well", func() {
-			Ω(ColorizeWithCode(xterm, str)).To(Equal(xtermResult))
+			Ω(ColorizeWithCode(xterm, str)).Should(Equal(xtermResult))
 		})
 	})
 
@@ -40,7 +40,7 @@ var _ = Describe("Color", func() {
 		)
 
 		It("colorizes with fallback values", func() {
-			Ω(ColorizeWithFallbackCode(code, str, true)).To(Equal(result))
+			Ω(ColorizeWithFallbackCode(code, str, true)).Should(Equal(result))
 		})
 	})
 
@@ -58,31 +58,31 @@ var _ = Describe("Color", func() {
 		)
 
 		It("processes all color codes in a string", func() {
-			Ω(Colorize(colored)).To(Equal(result))
+			Ω(Colorize(colored)).Should(Equal(result))
 		})
 
 		It("does nothing for plain strings", func() {
-			Ω(Colorize(str)).To(Equal(str))
+			Ω(Colorize(str)).Should(Equal(str))
 		})
 
 		It("does nothing for pre-colored strings", func() {
-			Ω(Colorize(Colorize(colored))).To(Equal(result))
+			Ω(Colorize(Colorize(colored))).Should(Equal(result))
 		})
 
 		It("does not replace escaped color codes", func() {
-			Ω(Colorize(escaped)).To(Equal(escapedResult))
+			Ω(Colorize(escaped)).Should(Equal(escapedResult))
 		})
 
 		It("colorizes background when putting a '-' before the code", func() {
-			Ω(Colorize(withBackground)).To(Equal(bgResult))
+			Ω(Colorize(withBackground)).Should(Equal(bgResult))
 		})
 
 		It("colorizes xterm 256 color codes", func() {
-			Ω(Colorize(withXterm)).To(Equal(xtermResult))
+			Ω(Colorize(withXterm)).Should(Equal(xtermResult))
 		})
 
 		It("falls back to ASCII from xterm when told to", func() {
-			Ω(ColorizeWithFallback(withXterm, true)).To(Equal(xtermFallbackResult))
+			Ω(ColorizeWithFallback(withXterm, true)).Should(Equal(xtermFallbackResult))
 		})
 	})
 
@@ -95,11 +95,11 @@ var _ = Describe("Color", func() {
 		)
 
 		It("removes all color codes from a string", func() {
-			Ω(Purge(colored)).To(Equal(result))
+			Ω(Purge(colored)).Should(Equal(result))
 		})
 
 		It("does not purge escaped color codes", func() {
-			Ω(Purge(escaped)).To(Equal(escapedResult))
+			Ω(Purge(escaped)).Should(Equal(escapedResult))
 		})
 	})
 
@@ -110,7 +110,7 @@ var _ = Describe("Color", func() {
 		)
 
 		It("escapes the ANSI escape sequence", func() {
-			Ω(Escape(Colorize(str))).To(Equal(result))
+			Ω(Escape(Colorize(str))).Should(Equal(result))
 		})
 	})
 })

--- a/assets/existence_test.go
+++ b/assets/existence_test.go
@@ -10,6 +10,6 @@ import (
 var _ = DescribeTable("Existence",
 	func(assetName string) {
 		_, err := Asset(assetName)
-		Ω(err).To(BeNil())
+		Ω(err).Should(BeNil())
 	},
 	Entry("Dragonfile.toml", "Dragonfile.toml"))

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Events", func() {
 
 			em.Emit("test1", nil)
 
-			Ω(<-c).To(Equal(true))
+			Ω(<-c).Should(Equal(true))
 			close(c)
 			close(done)
 		})
@@ -48,9 +48,9 @@ var _ = Describe("Events", func() {
 
 			em.Emit("test2", nil)
 
-			Ω(<-c).To(Equal(1))
-			Ω(<-c).To(Equal(2))
-			Ω(<-c).To(Equal(3))
+			Ω(<-c).Should(Equal(1))
+			Ω(<-c).Should(Equal(2))
+			Ω(<-c).Should(Equal(3))
 			close(c)
 			close(done)
 		})
@@ -111,9 +111,9 @@ var _ = Describe("Events", func() {
 
 			em.Emit("test3", NewData())
 
-			Ω(<-c).To(Equal(1))
-			Ω(<-c).To(Equal(2))
-			Ω(<-c).To(Equal(3))
+			Ω(<-c).Should(Equal(1))
+			Ω(<-c).Should(Equal(2))
+			Ω(<-c).Should(Equal(3))
 			close(c)
 			close(done)
 		})
@@ -127,7 +127,7 @@ var _ = Describe("Events", func() {
 			}))
 
 			em.Emit("test4", nil)
-			Ω(<-c).To(Equal(true))
+			Ω(<-c).Should(Equal(true))
 
 			// close and emit again, a panic from writing to closed channel is
 			// the failure we're looking for.
@@ -153,7 +153,7 @@ var _ = Describe("Events", func() {
 			}))
 
 			em.Emit("test5", nil)
-			Ω(<-c).To(Equal(1))
+			Ω(<-c).Should(Equal(1))
 			close(done)
 		})
 

--- a/logger/level_test.go
+++ b/logger/level_test.go
@@ -10,28 +10,28 @@ import (
 var _ = Describe("Level", func() {
 	Describe("generating log level from string", func() {
 		It("should default to debug", func() {
-			Ω(logger.GetLogLevel("")).To(Equal(logrus.DebugLevel))
+			Ω(logger.GetLogLevel("")).Should(Equal(logrus.DebugLevel))
 		})
 
 		It("should choose fatal level", func() {
-			Ω(logger.GetLogLevel("fatal")).To(Equal(logrus.FatalLevel))
+			Ω(logger.GetLogLevel("fatal")).Should(Equal(logrus.FatalLevel))
 		})
 
 		It("should choose panic level", func() {
-			Ω(logger.GetLogLevel("panic")).To(Equal(logrus.PanicLevel))
+			Ω(logger.GetLogLevel("panic")).Should(Equal(logrus.PanicLevel))
 		})
 
 		It("should choose warn level", func() {
-			Ω(logger.GetLogLevel("warn")).To(Equal(logrus.WarnLevel))
-			Ω(logger.GetLogLevel("warning")).To(Equal(logrus.WarnLevel))
+			Ω(logger.GetLogLevel("warn")).Should(Equal(logrus.WarnLevel))
+			Ω(logger.GetLogLevel("warning")).Should(Equal(logrus.WarnLevel))
 		})
 
 		It("should choose info level", func() {
-			Ω(logger.GetLogLevel("info")).To(Equal(logrus.InfoLevel))
+			Ω(logger.GetLogLevel("info")).Should(Equal(logrus.InfoLevel))
 		})
 
 		It("should choose debug level", func() {
-			Ω(logger.GetLogLevel("debug")).To(Equal(logrus.DebugLevel))
+			Ω(logger.GetLogLevel("debug")).Should(Equal(logrus.DebugLevel))
 		})
 	})
 })

--- a/logger/target_gen_test.go
+++ b/logger/target_gen_test.go
@@ -33,7 +33,7 @@ var _ = Describe("TargetGen", func() {
 	Context("nil targets", func() {
 		It("should return a console stdout reference", func() {
 			writer := logger.ConfigureTargets(nil)
-			Ω(writer).To(Equal(output.Stdout()))
+			Ω(writer).Should(Equal(output.Stdout()))
 		})
 	})
 
@@ -41,14 +41,14 @@ var _ = Describe("TargetGen", func() {
 		It("should panic", func() {
 			Ω(func() {
 				logger.ConfigureTargets(make(map[string]interface{}))
-			}).To(Panic())
+			}).Should(Panic())
 		})
 	})
 
 	Context("with a single target defined", func() {
 		It("should return a single io.Writer", func() {
 			writer := logger.ConfigureTargets(simpleMap)
-			Ω(writer).To(Equal(output.Stderr()))
+			Ω(writer).Should(Equal(output.Stderr()))
 		})
 	})
 
@@ -60,10 +60,10 @@ var _ = Describe("TargetGen", func() {
 		It("should create the writers", func() {
 			Ω(func() {
 				logger.ConfigureTargets(complexMap)
-			}).ToNot(Panic())
+			}).ShouldNot(Panic())
 			info, err := os.Stat("logger.log")
-			Ω(err).To(BeNil())
-			Ω(info.Name()).To(Equal("logger.log"))
+			Ω(err).Should(BeNil())
+			Ω(info.Name()).Should(Equal("logger.log"))
 		})
 	})
 })

--- a/output/console_test.go
+++ b/output/console_test.go
@@ -35,23 +35,23 @@ var _ = Describe("Console", func() {
 		It("accepts an fmt.Stringer", func() {
 			stringer := testStringer("testing")
 			console.Println(stringer)
-			Ω(buffer.String()).To(Equal("testing\n"))
+			Ω(buffer.String()).Should(Equal("testing\n"))
 		})
 
 		Context("arbitrary values", func() {
 			It("accpets integers", func() {
 				console.Println(10)
-				Ω(buffer.String()).To(Equal(fmt.Sprintf("%d\n", 10)))
+				Ω(buffer.String()).Should(Equal(fmt.Sprintf("%d\n", 10)))
 			})
 
 			It("accepts floats", func() {
 				console.Println(float32(1))
-				Ω(buffer.String()).To(Equal(fmt.Sprintf("%f\n", float32(1))))
+				Ω(buffer.String()).Should(Equal(fmt.Sprintf("%f\n", float32(1))))
 			})
 
 			It("accepts arbitrary values", func() {
 				console.Println(complex64(1))
-				Ω(buffer.String()).To(Equal(fmt.Sprintf("%v\n", complex64(1))))
+				Ω(buffer.String()).Should(Equal(fmt.Sprintf("%v\n", complex64(1))))
 			})
 		})
 	})
@@ -73,7 +73,7 @@ var _ = Describe("Console", func() {
 				})
 
 				It("purges color codes", func() {
-					Ω(buffer.String()).To(Equal("this is colored text\n"))
+					Ω(buffer.String()).Should(Equal("this is colored text\n"))
 				})
 			})
 
@@ -84,12 +84,12 @@ var _ = Describe("Console", func() {
 
 				It("processes colors and then prints", func() {
 					console.Println(coloredStr)
-					Ω(buffer.String()).To(Equal(result + "\n"))
+					Ω(buffer.String()).Should(Equal(result + "\n"))
 				})
 
 				It("uses fallback on xterm colors", func() {
 					console.Println(xtermStr)
-					Ω(buffer.String()).To(Equal(fallbackResult + "\n"))
+					Ω(buffer.String()).Should(Equal(fallbackResult + "\n"))
 				})
 			})
 
@@ -100,7 +100,7 @@ var _ = Describe("Console", func() {
 				})
 
 				It("processes colors and then prints", func() {
-					Ω(buffer.String()).To(Equal(xtermResult + "\n"))
+					Ω(buffer.String()).Should(Equal(xtermResult + "\n"))
 				})
 			})
 		})
@@ -113,7 +113,7 @@ var _ = Describe("Console", func() {
 				})
 
 				It("prints the text given to it", func() {
-					Ω(buffer.String()).To(Equal("testing"))
+					Ω(buffer.String()).Should(Equal("testing"))
 				})
 			})
 
@@ -124,12 +124,12 @@ var _ = Describe("Console", func() {
 
 				It("prints the text given to it", func() {
 					console.Printf("%s", coloredStr)
-					Ω(buffer.String()).To(Equal(result))
+					Ω(buffer.String()).Should(Equal(result))
 				})
 
 				It("uses fallback on xterm colors", func() {
 					console.Printf("%s", xtermStr)
-					Ω(buffer.String()).To(Equal(fallbackResult))
+					Ω(buffer.String()).Should(Equal(fallbackResult))
 				})
 			})
 
@@ -140,7 +140,7 @@ var _ = Describe("Console", func() {
 				})
 
 				It("processes colors and then prints", func() {
-					Ω(buffer.String()).To(Equal(xtermResult))
+					Ω(buffer.String()).Should(Equal(xtermResult))
 				})
 			})
 		})
@@ -153,7 +153,7 @@ var _ = Describe("Console", func() {
 				})
 
 				It("writes the text to the buffer without color", func() {
-					Ω(buffer.String()).To(Equal("testing"))
+					Ω(buffer.String()).Should(Equal("testing"))
 				})
 			})
 
@@ -164,12 +164,12 @@ var _ = Describe("Console", func() {
 
 				It("writes the text given to it", func() {
 					console.Printf("%s", coloredStr)
-					Ω(buffer.String()).To(Equal(result))
+					Ω(buffer.String()).Should(Equal(result))
 				})
 
 				It("uses fallback on xterm colors", func() {
 					console.Printf("%s", xtermStr)
-					Ω(buffer.String()).To(Equal(fallbackResult))
+					Ω(buffer.String()).Should(Equal(fallbackResult))
 				})
 			})
 
@@ -180,7 +180,7 @@ var _ = Describe("Console", func() {
 				})
 
 				It("writes the text to the buffer in color", func() {
-					Ω(buffer.String()).To(Equal(xtermResult))
+					Ω(buffer.String()).Should(Equal(xtermResult))
 				})
 			})
 		})
@@ -193,7 +193,7 @@ var _ = Describe("Console", func() {
 			})
 
 			It("prints the text passed to it with a newline", func() {
-				Ω(buffer.String()).To(Equal(str + "\n"))
+				Ω(buffer.String()).Should(Equal(str + "\n"))
 			})
 		})
 
@@ -203,7 +203,7 @@ var _ = Describe("Console", func() {
 			})
 
 			It("prints the text passed to it, based on format", func() {
-				Ω(buffer.String()).To(Equal(str))
+				Ω(buffer.String()).Should(Equal(str))
 			})
 		})
 	})
@@ -231,7 +231,7 @@ var _ = Describe("Console", func() {
 			})
 
 			It("prints to the expected place with color", func() {
-				Ω(buffer.String()).To(Equal(result + "\n"))
+				Ω(buffer.String()).Should(Equal(result + "\n"))
 			})
 
 			AfterEach(func() {
@@ -262,7 +262,7 @@ var _ = Describe("Console", func() {
 			})
 
 			It("prints to the expected place with color", func() {
-				Ω(buffer.String()).To(Equal(result + "\n"))
+				Ω(buffer.String()).Should(Equal(result + "\n"))
 			})
 
 			AfterEach(func() {

--- a/random/core_test.go
+++ b/random/core_test.go
@@ -16,20 +16,20 @@ var _ = Describe("Core", func() {
 
 	Describe("Intn", func() {
 		It("generates a random number", func() {
-			Ω(Intn(10)).To(Equal(1))
+			Ω(Intn(10)).Should(Equal(1))
 		})
 	})
 
 	Describe("Range", func() {
 		It("generates a random number", func() {
-			Ω(Range(1, 6)).To(Equal(2))
+			Ω(Range(1, 6)).Should(Equal(2))
 		})
 
 		It("generates a number between maximum and minimum value", func() {
 			for i := 0; i < 100000; i++ {
 				val := Range(10, 20)
-				Ω(val).To(BeNumerically(">=", 10))
-				Ω(val).To(BeNumerically("<=", 20))
+				Ω(val).Should(BeNumerically(">=", 10))
+				Ω(val).Should(BeNumerically("<=", 20))
 			}
 		})
 	})

--- a/random/dice_test.go
+++ b/random/dice_test.go
@@ -21,78 +21,78 @@ var _ = Describe("Die", func() {
 
 	Describe("D2", func() {
 		It("generates a random number", func() {
-			Ω(D2()).To(Equal(1))
+			Ω(D2()).Should(Equal(1))
 		})
 	})
 
 	Describe("D4", func() {
 		It("generates a random number", func() {
-			Ω(D4()).To(Equal(3))
+			Ω(D4()).Should(Equal(3))
 		})
 	})
 
 	Describe("D6", func() {
 		It("generates a random number", func() {
-			Ω(D6()).To(Equal(2))
+			Ω(D6()).Should(Equal(2))
 		})
 	})
 
 	Describe("D8", func() {
 		It("generates a random number", func() {
-			Ω(D8()).To(Equal(7))
+			Ω(D8()).Should(Equal(7))
 		})
 	})
 
 	Describe("D10", func() {
 		It("generates a random number", func() {
-			Ω(D10()).To(Equal(6))
+			Ω(D10()).Should(Equal(6))
 		})
 	})
 
 	Describe("D12", func() {
 		It("generates a random number", func() {
-			Ω(D12()).To(Equal(2))
+			Ω(D12()).Should(Equal(2))
 		})
 	})
 
 	Describe("D20", func() {
 		It("generates a random number", func() {
-			Ω(D20()).To(Equal(6))
+			Ω(D20()).Should(Equal(6))
 		})
 	})
 
 	Describe("D100", func() {
 		It("generates a random number", func() {
-			Ω(D100()).To(Equal(24))
+			Ω(D100()).Should(Equal(24))
 		})
 	})
 
 	Describe("RollDie", func() {
 		It("works without specifying a die count", func() {
-			Ω(RollDie("d10")).To(Equal([]int{6}))
+			Ω(RollDie("d10")).Should(Equal([]int{6}))
 		})
 
 		It("works with a die count", func() {
-			Ω(RollDie("2d20")).To(Equal([]int{6, 15}))
+			Ω(RollDie("2d20")).Should(Equal([]int{6, 15}))
 		})
 
 		It("returns nothing with an invalid count", func() {
-			Ω(RollDie("ad10")).To(Equal([]int{}))
+			Ω(RollDie("ad10")).Should(Equal([]int{}))
 		})
 
 		It("returns nothing with an invalid string", func() {
-			Ω(RollDie("a")).To(Equal([]int{}))
+			Ω(RollDie("a")).Should(Equal([]int{}))
 		})
 
 		It("returns nothing with an invalid side count", func() {
-			Ω(RollDie("1da")).To(Equal([]int{}))
+			Ω(RollDie("1da")).Should(Equal([]int{}))
 		})
 
 		It("generates values within the range specified", func() {
 			ret := RollDie("100000d2")
 			for _, n := range ret {
-				Ω(n).To(BeNumerically(">=", 1))
-				Ω(n).To(BeNumerically("<=", 2))
+				Ω(n).Should(BeNumerically(">=", 1))
+				Ω(n).Should(BeNumerically("<=", 2))
 			}
 		})
 	})

--- a/scripting/engine/lua_engine_test.go
+++ b/scripting/engine/lua_engine_test.go
@@ -33,7 +33,7 @@ var _ = Describe("LuaEngine", func() {
 
 		It("no longer functions", func() {
 			_, err := engine.Call("hello", 1, "World")
-			Ω(err).ToNot(BeNil())
+			Ω(err).ShouldNot(BeNil())
 		})
 	})
 
@@ -43,7 +43,7 @@ var _ = Describe("LuaEngine", func() {
 		})
 
 		It("should not fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		Context("when calling a method", func() {
@@ -57,19 +57,19 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("does not return an error", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("returns 1 result", func() {
-				Ω(len(results)).To(Equal(1))
+				Ω(len(results)).Should(Equal(1))
 			})
 
 			It("doesn't return nil", func() {
-				Ω(results[0]).ToNot(Equal(Nil))
+				Ω(results[0]).ShouldNot(Equal(Nil))
 			})
 
 			It("returns the string 'Hello, World!'", func() {
-				Ω(results[0].AsString()).To(Equal("Hello, World!"))
+				Ω(results[0].AsString()).Should(Equal("Hello, World!"))
 			})
 		})
 	})
@@ -80,7 +80,7 @@ var _ = Describe("LuaEngine", func() {
 		})
 
 		It("shoult not fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		Context("when calling a method", func() {
@@ -94,19 +94,19 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("does not return an error", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("return 1 result", func() {
-				Ω(len(results)).To(Equal(1))
+				Ω(len(results)).Should(Equal(1))
 			})
 
 			It("does not return nil", func() {
-				Ω(results[0]).ToNot(Equal(Nil))
+				Ω(results[0]).ShouldNot(Equal(Nil))
 			})
 
 			It("returns the number 1", func() {
-				Ω(results[0].AsNumber()).To(Equal(float64(1)))
+				Ω(results[0].AsNumber()).Should(Equal(float64(1)))
 			})
 		})
 	})
@@ -135,19 +135,19 @@ var _ = Describe("LuaEngine", func() {
 		})
 
 		It("does not return an error", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("returns two results", func() {
-			Ω(len(results)).To(Equal(2))
+			Ω(len(results)).Should(Equal(2))
 		})
 
 		It("returns the second input first", func() {
-			Ω(aResult).To(Equal(b))
+			Ω(aResult).Should(Equal(b))
 		})
 
 		It("returns the first input second", func() {
-			Ω(bResult).To(Equal(a))
+			Ω(bResult).Should(Equal(a))
 		})
 	})
 
@@ -171,15 +171,15 @@ var _ = Describe("LuaEngine", func() {
 		})
 
 		It("does not fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("returns one value", func() {
-			Ω(len(results)).To(Equal(1))
+			Ω(len(results)).Should(Equal(1))
 		})
 
 		It("returns the value assigned to the global", func() {
-			Ω(results[0].AsString()).To(Equal("testing"))
+			Ω(results[0].AsString()).Should(Equal("testing"))
 		})
 	})
 
@@ -200,11 +200,11 @@ var _ = Describe("LuaEngine", func() {
 		})
 
 		It("doesn't return nil", func() {
-			Ω(value).ToNot(Equal(Nil))
+			Ω(value).ShouldNot(Equal(Nil))
 		})
 
 		It("returns the correct string", func() {
-			Ω(value.AsString()).To(Equal("testing"))
+			Ω(value.AsString()).Should(Equal("testing"))
 		})
 	})
 
@@ -225,23 +225,23 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("should no fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("marks the called variable", func() {
-				Ω(called).To(BeTrue())
+				Ω(called).Should(BeTrue())
 			})
 
 			It("does not return nil", func() {
-				Ω(results[0]).ToNot(Equal(Nil))
+				Ω(results[0]).ShouldNot(Equal(Nil))
 			})
 
 			It("returns 1 value", func() {
-				Ω(len(results)).To(Equal(1))
+				Ω(len(results)).Should(Equal(1))
 			})
 
 			It("returns a value that passed through the Go function", func() {
-				Ω(results[0].AsNumber()).To(Equal(float64(21)))
+				Ω(results[0].AsNumber()).Should(Equal(float64(21)))
 			})
 		})
 
@@ -269,23 +269,23 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("does not fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("returns 1 value", func() {
-				Ω(len(results)).To(Equal(1))
+				Ω(len(results)).Should(Equal(1))
 			})
 
 			It("marks the variable called", func() {
-				Ω(called).To(BeTrue())
+				Ω(called).Should(BeTrue())
 			})
 
 			It("does not return nil", func() {
-				Ω(results[0]).ToNot(Equal(Nil))
+				Ω(results[0]).ShouldNot(Equal(Nil))
 			})
 
 			It("returns the correct value", func() {
-				Ω(results[0].AsNumber()).To(Equal(float64(1)))
+				Ω(results[0].AsNumber()).Should(Equal(float64(1)))
 			})
 		})
 	})
@@ -316,12 +316,12 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("should not fail", func() {
-				Ω(cerr).To(BeNil())
+				Ω(cerr).Should(BeNil())
 			})
 
 			It("should return the correct value", func() {
-				Ω(len(result)).To(BeNumerically(">", 0))
-				Ω(result[0].AsString()).To(Equal("success"))
+				Ω(len(result)).Should(BeNumerically(">", 0))
+				Ω(result[0].AsString()).Should(Equal("success"))
 			})
 		})
 
@@ -336,12 +336,12 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("should not fail", func() {
-				Ω(cerr).To(BeNil())
+				Ω(cerr).Should(BeNil())
 			})
 
 			It("should return the correct value", func() {
-				Ω(len(result)).To(BeNumerically(">", 0))
-				Ω(result[0].AsString()).To(Equal("success"))
+				Ω(len(result)).Should(BeNumerically(">", 0))
+				Ω(result[0].AsString()).Should(Equal("success"))
 			})
 		})
 	})
@@ -382,27 +382,27 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("didn't fail to fetch 'one'", func() {
-				Ω(errOne).To(BeNil())
+				Ω(errOne).Should(BeNil())
 			})
 
 			It("fetched a number", func() {
-				Ω(one.IsNumber()).To(BeTrue())
+				Ω(one.IsNumber()).Should(BeTrue())
 			})
 
 			It("fetch the number 2", func() {
-				Ω(one.AsNumber()).To(Equal(float64(2)))
+				Ω(one.AsNumber()).Should(Equal(float64(2)))
 			})
 
 			It("didn't fail to fetch 'two'", func() {
-				Ω(errTwo).To(BeNil())
+				Ω(errTwo).Should(BeNil())
 			})
 
 			It("fetched a string", func() {
-				Ω(two.IsString()).To(BeTrue())
+				Ω(two.IsString()).Should(BeTrue())
 			})
 
 			It("fetch the string 'too'", func() {
-				Ω(two.AsString()).To(Equal("too"))
+				Ω(two.AsString()).Should(Equal("too"))
 			})
 		})
 
@@ -422,31 +422,31 @@ var _ = Describe("LuaEngine", func() {
 			})
 
 			It("has 3 values", func() {
-				Ω(table.Len()).To(Equal(3))
+				Ω(table.Len()).Should(Equal(3))
 			})
 
 			It("didn't fail to fetch #1", func() {
-				Ω(errOne).To(BeNil())
+				Ω(errOne).Should(BeNil())
 			})
 
 			It("fetched a number", func() {
-				Ω(one.IsNumber()).To(BeTrue())
+				Ω(one.IsNumber()).Should(BeTrue())
 			})
 
 			It("fetch the number 1", func() {
-				Ω(one.AsNumber()).To(Equal(float64(1)))
+				Ω(one.AsNumber()).Should(Equal(float64(1)))
 			})
 
 			It("didn't fail to fetch #2", func() {
-				Ω(errTwo).To(BeNil())
+				Ω(errTwo).Should(BeNil())
 			})
 
 			It("fetched a number", func() {
-				Ω(two.IsNumber()).To(BeTrue())
+				Ω(two.IsNumber()).Should(BeTrue())
 			})
 
 			It("fetch the number 2", func() {
-				Ω(two.AsNumber()).To(Equal(float64(2)))
+				Ω(two.AsNumber()).Should(Equal(float64(2)))
 			})
 		})
 	})
@@ -468,12 +468,12 @@ var _ = Describe("LuaEngine", func() {
 
 		It("can call the whitelisted function", func() {
 			_, err := engine.Call("fromPtr", 1)
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("can't call the non-whitelisted function", func() {
 			_, err := engine.Call("fromValue", 1)
-			Ω(err).ToNot(BeNil())
+			Ω(err).ShouldNot(BeNil())
 		})
 	})
 
@@ -494,12 +494,12 @@ var _ = Describe("LuaEngine", func() {
 
 		It("can call the non-blacklisted function", func() {
 			_, err := engine.Call("fromPtr", 1)
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("can't call the blacklisted function", func() {
 			_, err := engine.Call("fromValue", 1)
-			Ω(err).ToNot(BeNil())
+			Ω(err).ShouldNot(BeNil())
 		})
 	})
 })

--- a/scripting/engine/lua_value_test.go
+++ b/scripting/engine/lua_value_test.go
@@ -37,13 +37,13 @@ var _ = Describe("LuaValue", func() {
 	It("conforms to fmt.Stringer", func() {
 		var iface interface{} = value(str)
 		str, ok := iface.(fmt.Stringer)
-		Ω(ok).To(BeTrue())
-		Ω(len(str.String())).To(BeNumerically(">", 0))
+		Ω(ok).Should(BeTrue())
+		Ω(len(str.String())).Should(BeNumerically(">", 0))
 	})
 
 	DescribeTable("AsString()",
 		func(val interface{}, expected string) {
-			Ω(value(val).AsString()).To(Equal(expected))
+			Ω(value(val).AsString()).Should(Equal(expected))
 		},
 		Entry("handles strings", str, str),
 		Entry("handles ints", i, "10"),
@@ -53,7 +53,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("AsFloat()",
 		func(val interface{}, expected float64) {
-			Ω(value(val).AsFloat()).To(Equal(expected))
+			Ω(value(val).AsFloat()).Should(Equal(expected))
 		},
 		Entry("handles int values", i, float64(i)),
 		Entry("handles int64 values", i64, float64(i64)),
@@ -62,14 +62,14 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("AsNumber()",
 		func(val interface{}, expected interface{}) {
-			Ω(value(val).AsNumber()).To(Equal(value(expected).AsFloat()))
+			Ω(value(val).AsNumber()).Should(Equal(value(expected).AsFloat()))
 		},
 		Entry("behaves just like AsFloat()", i, i),
 	)
 
 	DescribeTable("AsBool()",
 		func(val interface{}, expected bool) {
-			Ω(value(val).AsBool()).To(Equal(expected))
+			Ω(value(val).AsBool()).Should(Equal(expected))
 		},
 		Entry("handles bool values", b, true),
 		Entry("converts strings to bools", str, true),
@@ -78,7 +78,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("IsTrue()",
 		func(val interface{}, expected bool) {
-			Ω(value(val).IsTrue()).To(Equal(expected))
+			Ω(value(val).IsTrue()).Should(Equal(expected))
 		},
 		Entry("handles true", true, true),
 		Entry("handles false", false, false),
@@ -90,7 +90,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("IsFalse()",
 		func(val interface{}, expected bool) {
-			Ω(value(val).IsFalse()).To(Equal(expected))
+			Ω(value(val).IsFalse()).Should(Equal(expected))
 		},
 		Entry("handles true", true, false),
 		Entry("handles false", false, true),
@@ -102,7 +102,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("IsNil()",
 		func(val interface{}, expected bool) {
-			Ω(value(val).IsNil()).To(Equal(expected))
+			Ω(value(val).IsNil()).Should(Equal(expected))
 		},
 		Entry("does not think strings are nil", str, false),
 		Entry("does not think ints are nil", i, false),
@@ -113,7 +113,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("IsNumber()",
 		func(v interface{}, expected bool) {
-			Ω(value(v).IsNumber()).To(Equal(expected))
+			Ω(value(v).IsNumber()).Should(Equal(expected))
 		},
 		Entry("does not think strings are numbers", str, false),
 		Entry("thinks ints are numbers", i, true),
@@ -124,7 +124,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("IsBool()",
 		func(v interface{}, expected bool) {
-			Ω(value(v).IsBool()).To(Equal(expected))
+			Ω(value(v).IsBool()).Should(Equal(expected))
 		},
 		Entry("thinks true is a bool", true, true),
 		Entry("thinks false is a bool", false, true),
@@ -135,7 +135,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("IsFunction()",
 		func(v interface{}, expected bool) {
-			Ω(value(v).IsFunction()).To(Equal(expected))
+			Ω(value(v).IsFunction()).Should(Equal(expected))
 		},
 		Entry("thinks functions are functions", fn, true),
 		Entry("does not think strings are functions", str, false),
@@ -145,7 +145,7 @@ var _ = Describe("LuaValue", func() {
 
 	DescribeTable("IsString()",
 		func(v interface{}, expected bool) {
-			Ω(value(v).IsString()).To(Equal(expected))
+			Ω(value(v).IsString()).Should(Equal(expected))
 		},
 		Entry("thinks a string is a string", str, true),
 		Entry("does not think a number is a string", i, false),
@@ -165,19 +165,19 @@ var _ = Describe("LuaValue", func() {
 		})
 
 		It("has a length of 3", func() {
-			Ω(list.Len()).To(Equal(3))
+			Ω(list.Len()).Should(Equal(3))
 		})
 
 		It("contains a string at index 1", func() {
-			Ω(list.Get(1).AsString()).To(Equal(str))
+			Ω(list.Get(1).AsString()).Should(Equal(str))
 		})
 
 		It("contains a number at index 2", func() {
-			Ω(list.Get(2).AsNumber()).To(Equal(float64(i)))
+			Ω(list.Get(2).AsNumber()).Should(Equal(float64(i)))
 		})
 
 		It("contains a function at index 3", func() {
-			Ω(list.Get(3).IsFunction()).To(BeTrue())
+			Ω(list.Get(3).IsFunction()).Should(BeTrue())
 		})
 
 		Context("when calling functions on the list", func() {
@@ -191,15 +191,15 @@ var _ = Describe("LuaValue", func() {
 			})
 
 			It("should not fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("should return 1 result", func() {
-				Ω(len(results)).To(Equal(1))
+				Ω(len(results)).Should(Equal(1))
 			})
 
 			It("should return the correct value", func() {
-				Ω(results[0].AsNumber()).To(Equal(float64(int64(i) + i64)))
+				Ω(results[0].AsNumber()).Should(Equal(float64(int64(i) + i64)))
 			})
 		})
 
@@ -225,15 +225,15 @@ var _ = Describe("LuaValue", func() {
 			})
 
 			It("found a string", func() {
-				Ω(isString).To(BeTrue())
+				Ω(isString).Should(BeTrue())
 			})
 
 			It("found a number", func() {
-				Ω(isNumber).To(BeTrue())
+				Ω(isNumber).Should(BeTrue())
 			})
 
 			It("found a function", func() {
-				Ω(isFunction).To(BeTrue())
+				Ω(isFunction).Should(BeTrue())
 			})
 		})
 
@@ -243,7 +243,7 @@ var _ = Describe("LuaValue", func() {
 			})
 
 			It("changed the value at index 2", func() {
-				Ω(list.Get(2).AsNumber()).To(Equal(float64(i64)))
+				Ω(list.Get(2).AsNumber()).Should(Equal(float64(i64)))
 			})
 		})
 
@@ -253,12 +253,12 @@ var _ = Describe("LuaValue", func() {
 			})
 
 			It("remove the value at index 2", func() {
-				Ω(list.Get(2).IsFunction()).To(BeTrue())
+				Ω(list.Get(2).IsFunction()).Should(BeTrue())
 			})
 		})
 	})
 
-	Describe("ToMap()", func() {
+	Describe("AsMapStringInterface()", func() {
 		var (
 			table *LuaValue
 			m     map[string]interface{}
@@ -268,27 +268,27 @@ var _ = Describe("LuaValue", func() {
 			table = engine.NewTable()
 			table.Set("one", 1)
 			table.Set("two", "two")
-			m = table.ToMap()
+			m = table.AsMapStringInterface()
 		})
 
 		It("has two keys", func() {
-			Ω(m).To(HaveLen(2))
+			Ω(m).Should(HaveLen(2))
 		})
 
 		It("has the number 1 at 'one'", func() {
 			n, ok := m["one"]
-			Ω(ok).To(BeTrue())
-			Ω(n).To(Equal(float64(1)))
+			Ω(ok).Should(BeTrue())
+			Ω(n).Should(Equal(float64(1)))
 		})
 
 		It("has the string 'two' at 'two'", func() {
 			s, ok := m["two"]
-			Ω(ok).To(BeTrue())
-			Ω(s).To(Equal("two"))
+			Ω(ok).Should(BeTrue())
+			Ω(s).Should(Equal("two"))
 		})
 	})
 
-	Describe("ToSlice()", func() {
+	Describe("AsSliceInterface()", func() {
 		var (
 			table *LuaValue
 			s     []interface{}
@@ -298,19 +298,19 @@ var _ = Describe("LuaValue", func() {
 			table = engine.NewTable()
 			table.Append(2)
 			table.Append(1)
-			s = table.ToSlice()
+			s = table.AsSliceInterface()
 		})
 
 		It("has a length of 2", func() {
-			Ω(s).To(HaveLen(2))
+			Ω(s).Should(HaveLen(2))
 		})
 
 		It("has the value 2 at index 0", func() {
-			Ω(s[0]).To(Equal(float64(2)))
+			Ω(s[0]).Should(Equal(float64(2)))
 		})
 
 		It("has the value 1 at index 1", func() {
-			Ω(s[1]).To(Equal(float64(1)))
+			Ω(s[1]).Should(Equal(float64(1)))
 		})
 	})
 })

--- a/scripting/modules/die_test.go
+++ b/scripting/modules/die_test.go
@@ -19,20 +19,20 @@ func testDie(e *engine.Lua, method string, min, max float64) {
 		}
 
 		It("doesn't fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("should be in the correct range", func() {
-			Ω(result).To(BeNumerically(">=", min))
-			Ω(result).To(BeNumerically("<=", max))
+			Ω(result).Should(BeNumerically(">=", min))
+			Ω(result).Should(BeNumerically("<=", max))
 		})
 	})
 }
 
 func validateRange(i interface{}, min, max float64) {
 	It("is in the correct range", func() {
-		Ω(i).To(BeNumerically(">=", min))
-		Ω(i).To(BeNumerically("<=", max))
+		Ω(i).Should(BeNumerically(">=", min))
+		Ω(i).Should(BeNumerically("<=", max))
 	})
 }
 
@@ -63,15 +63,15 @@ var _ = Describe("Die", func() {
 		res, err := e.Call("rollDie", 1, "3d8")
 		var results []interface{}
 		if len(res) > 0 {
-			results = res[0].ToSlice()
+			results = res[0].AsSliceInterface()
 		}
 
 		It("doesn't fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("generated 3 values", func() {
-			Ω(results).To(HaveLen(3))
+			Ω(results).Should(HaveLen(3))
 		})
 
 		for _, i := range results {

--- a/scripting/modules/events.go
+++ b/scripting/modules/events.go
@@ -22,7 +22,7 @@ var Events = map[string]interface{}{
 
 		var data events.Data
 		if dataVal.IsTable() {
-			data = events.Data(dataVal.ToMap())
+			data = events.Data(dataVal.AsMapStringInterface())
 		}
 
 		lpool := engine.GetGlobal(keys.Pool)

--- a/scripting/modules/password_test.go
+++ b/scripting/modules/password_test.go
@@ -51,22 +51,22 @@ var _ = Describe("password Module", func() {
 	})
 
 	It("doesn't fail", func() {
-		Ω(err).To(BeNil())
+		Ω(err).Should(BeNil())
 	})
 
 	It("doesn't generate empty strings", func() {
-		Ω(result).ToNot(Equal(""))
+		Ω(result).ShouldNot(Equal(""))
 	})
 
 	It("generates the correct hash length", func() {
-		Ω(result).To(HaveLen(32))
+		Ω(result).Should(HaveLen(32))
 	})
 
 	It("generates the same hash with matching inputs", func() {
-		Ω(valid).To(BeTrue())
+		Ω(valid).Should(BeTrue())
 	})
 
 	It("hashes different passwords, differently", func() {
-		Ω(invalid).To(BeFalse())
+		Ω(invalid).Should(BeFalse())
 	})
 })

--- a/scripting/modules/random_test.go
+++ b/scripting/modules/random_test.go
@@ -31,12 +31,12 @@ var _ = Describe("Random", func() {
 		}
 
 		It("doesn't fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("is in valid range", func() {
-			Ω(result).To(BeNumerically(">=", 0))
-			Ω(result).To(BeNumerically("<", 100))
+			Ω(result).Should(BeNumerically(">=", 0))
+			Ω(result).Should(BeNumerically("<", 100))
 		})
 	})
 
@@ -48,12 +48,12 @@ var _ = Describe("Random", func() {
 		}
 
 		It("doesn't fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("is in valid range", func() {
-			Ω(result).To(BeNumerically(">=", 50))
-			Ω(result).To(BeNumerically("<", 90))
+			Ω(result).Should(BeNumerically(">=", 50))
+			Ω(result).Should(BeNumerically("<", 90))
 		})
 	})
 })

--- a/scripting/modules/tmpl.go
+++ b/scripting/modules/tmpl.go
@@ -36,7 +36,7 @@ var Tmpl = map[string]interface{}{
 		data := engine.PopTable()
 		name := engine.PopString()
 
-		log := tmplLog.WithField("name", name)
+		log := tmplLog.WithField("tmpl_name", name)
 
 		t, err := tmpl.Template(name)
 		if err != nil {
@@ -47,12 +47,11 @@ var Tmpl = map[string]interface{}{
 
 			return 2
 		}
-		mapData := data.AsMapStringInterface()
-		result, err := t.Render(mapData)
+		result, err := t.Render(data)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"error": err.Error(),
-				"data":  mapData,
+				"data":  data.AsMapStringInterface(),
 			}).Error("Failed to render template from requested in script.")
 		}
 

--- a/scripting/modules/tmpl_test.go
+++ b/scripting/modules/tmpl_test.go
@@ -42,16 +42,16 @@ var _ = Describe("tmpl Module", func() {
 	})
 
 	It("successfully calls the script method", func() {
-		Ω(err).To(BeNil())
+		Ω(err).Should(BeNil())
 	})
 
 	It("doesn't fail", func() {
-		Ω(err).To(BeNil())
-		Ω(ok).To(BeTrue())
+		Ω(err).Should(BeNil())
+		Ω(ok).Should(BeTrue())
 	})
 
 	It("should render correctly", func() {
-		Ω(err).To(BeNil())
-		Ω(result).To(Equal("Hello, World!"))
+		Ω(err).Should(BeNil())
+		Ω(result).Should(Equal("Hello, World!"))
 	})
 })

--- a/talon/connect_options_test.go
+++ b/talon/connect_options_test.go
@@ -18,7 +18,7 @@ var _ = Describe("ConnectOptions", func() {
 
 		GeneratesCorrectURL := func() {
 			It("generates the correct URL", func() {
-				Ω(co.URL()).To(Equal(expected))
+				Ω(co.URL()).Should(Equal(expected))
 			})
 		}
 

--- a/talon/live_db_test.go
+++ b/talon/live_db_test.go
@@ -66,7 +66,7 @@ var _ = Describe("LiveDB", func() {
 		})
 
 		It("doesn't fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 	})
 
@@ -87,7 +87,7 @@ var _ = Describe("LiveDB", func() {
 				})
 
 				It("should not fail", func() {
-					Ω(err).To(BeNil())
+					Ω(err).Should(BeNil())
 				})
 			})
 
@@ -97,46 +97,46 @@ var _ = Describe("LiveDB", func() {
 
 					result, err := db.Cypher(`CREATE (:TalonSingleNodeTest {hello: "world"})`).Exec()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(result.Stats.LabelsAdded).To(BeEquivalentTo(1))
-					Ω(result.Stats.NodesCreated).To(BeEquivalentTo(1))
-					Ω(result.Stats.PropertiesSet).To(BeEquivalentTo(1))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(result.Stats.LabelsAdded).Should(BeEquivalentTo(1))
+					Ω(result.Stats.NodesCreated).Should(BeEquivalentTo(1))
+					Ω(result.Stats.PropertiesSet).Should(BeEquivalentTo(1))
 
 					By("accessing the node")
 
 					rows, err := db.Cypher(`MATCH (n:TalonSingleNodeTest) RETURN n`).Query()
 					defer rows.Close()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(rows).ToNot(BeNil())
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(rows).ShouldNot(BeNil())
 
 					row, err := rows.Next()
 
 					// examine rows
-					Ω(err).ToNot(HaveOccurred())
-					Ω(row).To(HaveLen(1))
-					Ω(row[0].Type()).To(Equal(EntityNode))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(row).Should(HaveLen(1))
+					Ω(row[0].Type()).Should(Equal(EntityNode))
 
 					// examine node
 					node := row[0].(*Node)
-					Ω(node.Labels).To(HaveLen(1))
-					Ω(node.Labels).To(ContainElement("TalonSingleNodeTest"))
-					Ω(node.Properties).To(HaveLen(1))
-					Ω(node.Properties).To(HaveKey("hello"))
-					Ω(node.Properties["hello"]).To(Equal("world"))
+					Ω(node.Labels).Should(HaveLen(1))
+					Ω(node.Labels).Should(ContainElement("TalonSingleNodeTest"))
+					Ω(node.Properties).Should(HaveLen(1))
+					Ω(node.Properties).Should(HaveKey("hello"))
+					Ω(node.Properties["hello"]).Should(Equal("world"))
 
 					row, err = rows.Next()
 
-					Ω(row).To(HaveLen(0))
-					Ω(err).To(MatchError(io.EOF))
+					Ω(row).Should(HaveLen(0))
+					Ω(err).Should(MatchError(io.EOF))
 
 					By("deleting nodes")
 
 					result, err = db.Cypher("MATCH (n:TalonSingleNodeTest) DELETE n").Exec()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(result).ToNot(BeNil())
-					Ω(result.Stats.NodesDeleted).To(BeEquivalentTo(1))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(result).ShouldNot(BeNil())
+					Ω(result.Stats.NodesDeleted).Should(BeEquivalentTo(1))
 				})
 			})
 
@@ -146,51 +146,51 @@ var _ = Describe("LiveDB", func() {
 
 					result, err := db.Cypher("CREATE (a:TalonSingleRelTest {id: 1}), (b:TalonSingleRelTest {id: 2})").Exec()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(result.Stats.NodesCreated).To(BeEquivalentTo(2))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(result.Stats.NodesCreated).Should(BeEquivalentTo(2))
 
 					By("creating relationship")
 
 					result, err = db.Cypher(`MATCH (a:TalonSingleRelTest {id: 1}), (b:TalonSingleRelTest {id: 2}) CREATE (a)-[:TALON_TEST_RELATIONSHIP {hello: "world"}]->(b)`).Exec()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(result.Stats.RelationshipsCreated).To(BeEquivalentTo(1))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(result.Stats.RelationshipsCreated).Should(BeEquivalentTo(1))
 
 					By("fetching the relationship")
 
 					rows, err := db.Cypher("MATCH ()-[r:TALON_TEST_RELATIONSHIP]->() RETURN r").Query()
 					defer rows.Close()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(rows).ToNot(BeNil())
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(rows).ShouldNot(BeNil())
 
 					row, err := rows.Next()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(row).To(HaveLen(1))
-					Ω(row[0].Type()).To(Equal(EntityRelationship))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(row).Should(HaveLen(1))
+					Ω(row[0].Type()).Should(Equal(EntityRelationship))
 
 					rel := row[0].(*Relationship)
-					Ω(rel.Name).To(Equal("TALON_TEST_RELATIONSHIP"))
-					Ω(rel.StartNodeID).To(BeNumerically(">", 0))
-					Ω(rel.EndNodeID).To(And(
+					Ω(rel.Name).Should(Equal("TALON_TEST_RELATIONSHIP"))
+					Ω(rel.StartNodeID).Should(BeNumerically(">", 0))
+					Ω(rel.EndNodeID).Should(And(
 						BeNumerically(">", 0),
 						Not(Equal(rel.StartNodeID)),
 					))
-					Ω(rel.Properties).To(HaveKey("hello"))
-					Ω(rel.Properties["hello"]).To(Equal("world"))
+					Ω(rel.Properties).Should(HaveKey("hello"))
+					Ω(rel.Properties["hello"]).Should(Equal("world"))
 
 					row, err = rows.Next()
-					Ω(row).To(HaveLen(0))
-					Ω(err).To(MatchError(io.EOF))
+					Ω(row).Should(HaveLen(0))
+					Ω(err).Should(MatchError(io.EOF))
 
 					By("deleting the relationship")
 
 					result, err = db.Cypher("MATCH (n)-[r:TALON_TEST_RELATIONSHIP]->(n2) DELETE r, n, n2").Exec()
 
-					Ω(err).ToNot(HaveOccurred())
-					Ω(result.Stats.NodesDeleted).To(BeEquivalentTo(2))
-					Ω(result.Stats.RelationshipsDeleted).To(BeEquivalentTo(1))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(result.Stats.NodesDeleted).Should(BeEquivalentTo(2))
+					Ω(result.Stats.RelationshipsDeleted).Should(BeEquivalentTo(1))
 				})
 			})
 		})

--- a/talon/types/complex_test.go
+++ b/talon/types/complex_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Complex", func() {
 			)
 
 			It("returns a wrapped complex128", func() {
-				Ω(complex128(c)).To(Equal(c64to128))
+				Ω(complex128(c)).Should(Equal(c64to128))
 			})
 		})
 
@@ -32,7 +32,7 @@ var _ = Describe("Complex", func() {
 			c := NewComplex(c128)
 
 			It("wraps the complex128", func() {
-				Ω(complex128(c)).To(Equal(c128))
+				Ω(complex128(c)).Should(Equal(c128))
 			})
 		})
 
@@ -40,7 +40,7 @@ var _ = Describe("Complex", func() {
 			c := NewComplex("")
 
 			It("returns a zero complex", func() {
-				Ω(complex128(c)).To(Equal(zero))
+				Ω(complex128(c)).Should(Equal(zero))
 			})
 		})
 	})
@@ -62,11 +62,11 @@ var _ = Describe("Complex", func() {
 		})
 
 		It("doesn't fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("produces the correct string", func() {
-			Ω(result).To(Equal(expected))
+			Ω(result).Should(Equal(expected))
 		})
 	})
 
@@ -84,11 +84,11 @@ var _ = Describe("Complex", func() {
 		})
 
 		It("doesn't fail", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 
 		It("produces the correct complex value", func() {
-			Ω(complex128(c)).To(Equal(expected))
+			Ω(complex128(c)).Should(Equal(expected))
 		})
 	})
 })

--- a/talon/types/properties_test.go
+++ b/talon/types/properties_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Properties", func() {
 	Describe("QueryString", func() {
 		Context("when the property map is empty", func() {
 			It("is just an empty string", func() {
-				Ω(p.QueryString()).To(Equal(""))
+				Ω(p.QueryString()).Should(Equal(""))
 			})
 		})
 
@@ -29,7 +29,7 @@ var _ = Describe("Properties", func() {
 			})
 
 			It("is a key-insertion pairing", func() {
-				Ω(p.QueryString()).To(Equal(`{one: {one}}`))
+				Ω(p.QueryString()).Should(Equal(`{one: {one}}`))
 			})
 		})
 
@@ -40,7 +40,7 @@ var _ = Describe("Properties", func() {
 			})
 
 			It("is a key-insertion pairing", func() {
-				Ω(p.QueryString()).To(Equal(`{one: {one}, three: {three}}`))
+				Ω(p.QueryString()).Should(Equal(`{one: {one}, three: {three}}`))
 			})
 		})
 
@@ -53,7 +53,7 @@ var _ = Describe("Properties", func() {
 			})
 
 			It("is a key-insertion pairing", func() {
-				Ω(p.QueryString()).To(Equal(`{one: {one}}`))
+				Ω(p.QueryString()).Should(Equal(`{one: {one}}`))
 			})
 		})
 	})

--- a/talon/types/time_test.go
+++ b/talon/types/time_test.go
@@ -34,11 +34,11 @@ var _ = Describe("TimeType", func() {
 			})
 
 			It("doesn't fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("produces the correct string", func() {
-				Ω(string(bs)).To(Equal(test))
+				Ω(string(bs)).Should(Equal(test))
 			})
 		})
 
@@ -51,11 +51,11 @@ var _ = Describe("TimeType", func() {
 			})
 
 			It("doesn't fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("produces the correct string", func() {
-				Ω(string(bs)).To(Equal(test))
+				Ω(string(bs)).Should(Equal(test))
 			})
 		})
 	})
@@ -70,31 +70,31 @@ var _ = Describe("TimeType", func() {
 			})
 
 			It("doesn't fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("parsed correct year", func() {
-				Ω(t.Year()).To(Equal(1986))
+				Ω(t.Year()).Should(Equal(1986))
 			})
 
 			It("parsed correct month", func() {
-				Ω(t.Month()).To(Equal(time.November))
+				Ω(t.Month()).Should(Equal(time.November))
 			})
 
 			It("parsed the correct day", func() {
-				Ω(t.Day()).To(Equal(12))
+				Ω(t.Day()).Should(Equal(12))
 			})
 
 			It("parsed the correct hour", func() {
-				Ω(t.Hour()).To(Equal(1))
+				Ω(t.Hour()).Should(Equal(1))
 			})
 
 			It("parsed the correct minute", func() {
-				Ω(t.Minute()).To(Equal(2))
+				Ω(t.Minute()).Should(Equal(2))
 			})
 
 			It("parsed the correct second", func() {
-				Ω(t.Second()).To(Equal(3))
+				Ω(t.Second()).Should(Equal(3))
 			})
 		})
 
@@ -107,31 +107,31 @@ var _ = Describe("TimeType", func() {
 			})
 
 			It("doesn't fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("parsed correct year", func() {
-				Ω(t.Year()).To(Equal(1986))
+				Ω(t.Year()).Should(Equal(1986))
 			})
 
 			It("parsed correct month", func() {
-				Ω(t.Month()).To(Equal(time.November))
+				Ω(t.Month()).Should(Equal(time.November))
 			})
 
 			It("parsed the correct day", func() {
-				Ω(t.Day()).To(Equal(12))
+				Ω(t.Day()).Should(Equal(12))
 			})
 
 			It("parsed the correct hour", func() {
-				Ω(t.Hour()).To(Equal(1))
+				Ω(t.Hour()).Should(Equal(1))
 			})
 
 			It("parsed the correct minute", func() {
-				Ω(t.Minute()).To(Equal(2))
+				Ω(t.Minute()).Should(Equal(2))
 			})
 
 			It("parsed the correct second", func() {
-				Ω(t.Second()).To(Equal(3))
+				Ω(t.Second()).Should(Equal(3))
 			})
 		})
 	})

--- a/text/tmpl/fasttemplate_renderer.go
+++ b/text/tmpl/fasttemplate_renderer.go
@@ -4,7 +4,10 @@ package tmpl
 
 import (
 	"io"
+	"reflect"
 
+	"github.com/bbuck/dragon-mud/scripting/engine"
+	"github.com/fatih/structs"
 	"github.com/valyala/fasttemplate"
 )
 
@@ -14,16 +17,36 @@ type fastTemplateRenderer struct {
 
 // Render will use the fasttemplates ExecuteString method to produce a string
 // from the template and data provided.
-func (f *fastTemplateRenderer) Render(data map[string]interface{}) (string, error) {
-	result := f.template.ExecuteString(data)
+func (f *fastTemplateRenderer) Render(data interface{}) (string, error) {
+	result := f.template.ExecuteString(ifaceToMap(data))
 
 	return result, nil
 }
 
 // RenderTo will use the fasttemplates Execute method to render a template to
 // and io.Writer using the data provided.
-func (f *fastTemplateRenderer) RenderTo(w io.Writer, data map[string]interface{}) error {
-	_, err := f.template.Execute(w, data)
+func (f *fastTemplateRenderer) RenderTo(w io.Writer, data interface{}) error {
+	_, err := f.template.Execute(w, ifaceToMap(data))
 
 	return err
+}
+
+func ifaceToMap(i interface{}) map[string]interface{} {
+	if m, ok := i.(map[string]interface{}); ok {
+		return m
+	}
+
+	if reflect.ValueOf(i).Kind() == reflect.Struct {
+		st := structs.New(i)
+
+		return st.Map()
+	}
+
+	if lv, ok := i.(*engine.LuaValue); ok {
+		if lv.IsTable() {
+			return lv.AsMapStringInterface()
+		}
+	}
+
+	return nil
 }

--- a/text/tmpl/renderer.go
+++ b/text/tmpl/renderer.go
@@ -7,6 +7,6 @@ import "io"
 // Renderer is an interface defining the necessary methods for interacting with
 // a templtae engine.
 type Renderer interface {
-	Render(map[string]interface{}) (string, error)
-	RenderTo(io.Writer, map[string]interface{}) error
+	Render(interface{}) (string, error)
+	RenderTo(io.Writer, interface{}) error
 }

--- a/text/tmpl/renderer_test.go
+++ b/text/tmpl/renderer_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var templateWithBraces = "{{this}} should have {braces}"
+var templateWithBraces = "{{This}} should have {braces}"
 
 var _ = Describe("Renderer", func() {
 	Describe("Render", func() {
@@ -15,10 +15,10 @@ var _ = Describe("Renderer", func() {
 			var (
 				r     Renderer
 				data1 = map[string]interface{}{
-					"name": "World",
+					"Name": "World",
 				}
 				data2 = map[string]interface{}{
-					"name": "Mundo",
+					"Name": "Mundo",
 				}
 				result1, result2 string
 				err1, err2       error
@@ -33,16 +33,16 @@ var _ = Describe("Renderer", func() {
 			})
 
 			It("does not fail", func() {
-				Ω(err1).To(BeNil())
-				Ω(err2).To(BeNil())
+				Ω(err1).Should(BeNil())
+				Ω(err2).Should(BeNil())
 			})
 
 			It("renders to a string", func() {
-				Ω(result1).To(Equal("Hello, World!"))
+				Ω(result1).Should(Equal("Hello, World!"))
 			})
 
 			It("renders with different results", func() {
-				Ω(result2).To(Equal("Hello, Mundo!"))
+				Ω(result2).Should(Equal("Hello, Mundo!"))
 			})
 		})
 
@@ -52,7 +52,7 @@ var _ = Describe("Renderer", func() {
 				result string
 				err    error
 				data   = map[string]interface{}{
-					"this": "This",
+					"This": "This",
 				}
 			)
 
@@ -64,11 +64,38 @@ var _ = Describe("Renderer", func() {
 			})
 
 			It("doesn't fail", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("renders correctly", func() {
-				Ω(result).To(Equal("This should have {braces}"))
+				Ω(result).Should(Equal("This should have {braces}"))
+			})
+		})
+
+		Context("when given a struct instead of a map", func() {
+			var (
+				r      Renderer
+				result string
+				err    error
+				data   = struct {
+					Name string
+				}{
+					Name: "Mundo",
+				}
+			)
+
+			BeforeEach(func() {
+				Register(testTemplate, "test")
+				r, _ = Template("test")
+				result, err = r.Render(data)
+			})
+
+			It("doesn't fail to render", func() {
+				Ω(err).Should(BeNil())
+			})
+
+			It("renders the correct string", func() {
+				Ω(result).Should(Equal("Hello, Mundo!"))
 			})
 		})
 	})

--- a/text/tmpl/templates_test.go
+++ b/text/tmpl/templates_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var testTemplate = "Hello, {{name}}!"
+var testTemplate = "Hello, {{Name}}!"
 
 var _ = Describe("Templates", func() {
 	Describe("Register", func() {
@@ -22,7 +22,7 @@ var _ = Describe("Templates", func() {
 		})
 
 		It("should not error", func() {
-			Ω(err).To(BeNil())
+			Ω(err).Should(BeNil())
 		})
 	})
 
@@ -43,11 +43,11 @@ var _ = Describe("Templates", func() {
 			})
 
 			It("does not return an error", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			It("returns an error", func() {
-				Ω(r).ToNot(BeNil())
+				Ω(r).ShouldNot(BeNil())
 			})
 		})
 
@@ -57,11 +57,11 @@ var _ = Describe("Templates", func() {
 			})
 
 			It("does not return an error", func() {
-				Ω(r).To(BeNil())
+				Ω(r).Should(BeNil())
 			})
 
 			It("does return an error", func() {
-				Ω(err).ToNot(BeNil())
+				Ω(err).ShouldNot(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
The revision in language from `To` back to `Should` is due to my preference in using `Ω` instead of `Expect`. `Expect(...).To(...)` is a good match, but `Ω(...).To(...)` like `Ω(str).To(Equal("thing"))` reads like "string to equal 'thing'" where-as `Ω(str).Should(Equal("thing"))` reads like `string should equal 'thing'" which is _much_ better.